### PR TITLE
Add simple GUI for generating metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Metadata Generator
-A tool to create metadata for digital artwork editions
+A tool to create metadata for digital artwork editions.
+
+## GUI Usage
+
+The project now includes a native GUI built with `eframe`. Run it with:
+
+```bash
+cargo run --bin gui
+```
+
+Use the **Browse for folder** button to select the directory containing your
+files, fill in the artwork details and press **Generate metadata**. A JSON file
+named `<title>_metadata.json` will be saved to the selected folder.

--- a/metadata-generator/Cargo.toml
+++ b/metadata-generator/Cargo.toml
@@ -18,3 +18,5 @@ log = "0.4"
 serde = {version = "1.0.204", features = ["derive"] }
 serde_json = "1.0"
 memmap = "0.7"
+eframe = "0.27"
+rfd = "0.14"

--- a/metadata-generator/src/bin/gui.rs
+++ b/metadata-generator/src/bin/gui.rs
@@ -1,0 +1,135 @@
+use eframe::{egui, App, Frame};
+use rfd::FileDialog;
+use std::fs::{self, File};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+
+#[path = "../blake3_hash.rs"]
+mod blake3_hash;
+use blake3_hash::hasher;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default)]
+struct MediaFile {
+    file_name: String,
+    file_hash: String,
+    file_size: u64,
+    file_type: String,
+    file_path: String,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+struct Metadata {
+    date_created: String,
+    title: String,
+    creator: String,
+    description: String,
+    video_files: Vec<MediaFile>,
+    audio_files: Vec<MediaFile>,
+}
+
+struct GuiApp {
+    folder: Option<PathBuf>,
+    date: String,
+    title: String,
+    creator: String,
+    description: String,
+    status: String,
+}
+
+impl Default for GuiApp {
+    fn default() -> Self {
+        Self {
+            folder: None,
+            date: String::new(),
+            title: String::new(),
+            creator: String::new(),
+            description: String::new(),
+            status: String::new(),
+        }
+    }
+}
+
+impl App for GuiApp {
+    fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
+        egui::CentralPanel::default().show(ctx, |ui| {
+            ui.heading("Metadata Generator");
+            if ui.button("Browse for folder").clicked() {
+                if let Some(dir) = FileDialog::new().pick_folder() {
+                    self.folder = Some(dir);
+                }
+            }
+            if let Some(folder) = &self.folder {
+                ui.label(format!("Folder: {}", folder.display()));
+            }
+
+            ui.separator();
+            ui.label("Date created");
+            ui.text_edit_singleline(&mut self.date);
+            ui.label("Title");
+            ui.text_edit_singleline(&mut self.title);
+            ui.label("Creator");
+            ui.text_edit_singleline(&mut self.creator);
+            ui.label("Description");
+            ui.text_edit_multiline(&mut self.description);
+
+            if ui.button("Generate metadata").clicked() {
+                match self.generate() {
+                    Ok(p) => self.status = format!("Saved to {}", p.display()),
+                    Err(e) => self.status = format!("Error: {}", e),
+                }
+            }
+
+            ui.separator();
+            ui.label(&self.status);
+        });
+    }
+
+}
+
+impl GuiApp {
+    fn generate(&self) -> std::io::Result<PathBuf> {
+        let folder = self.folder.clone().ok_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "No folder selected"))?;
+        let entries = fs::read_dir(&folder)?;
+
+        let mut metadata = Metadata {
+            date_created: self.date.clone(),
+            title: self.title.clone(),
+            creator: self.creator.clone(),
+            description: self.description.clone(),
+            video_files: Vec::new(),
+            audio_files: Vec::new(),
+        };
+
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                let path_str = path.to_string_lossy().to_string();
+                let hash = hasher::hash_file(&path_str)?;
+                let mf = MediaFile {
+                    file_name: path.file_name().unwrap().to_string_lossy().to_string(),
+                    file_hash: hash,
+                    file_size: path.metadata()?.len(),
+                    file_type: path.extension().unwrap_or_default().to_string_lossy().to_string(),
+                    file_path: path_str,
+                };
+                metadata.video_files.push(mf);
+            }
+        }
+
+        let file_name = format!("{}_metadata.json", self.title.replace(' ', "_"));
+        let output = folder.join(file_name);
+        let file = File::create(&output)?;
+        let mut writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(&mut writer, &metadata)?;
+        writer.flush()?;
+        Ok(output)
+    }
+}
+
+fn main() -> Result<(), eframe::Error> {
+    let app = GuiApp::default();
+    let native_options = eframe::NativeOptions::default();
+    eframe::run_native("Metadata Generator", native_options, Box::new(|_cc| Box::new(app)))
+}

--- a/metadata-generator/src/blake3_hash.rs
+++ b/metadata-generator/src/blake3_hash.rs
@@ -4,7 +4,7 @@ pub mod hasher {
     use std::{fs::File, sync::{atomic::{AtomicBool, AtomicU64, Ordering}, Arc}, thread, time::Duration};
     use memmap::Mmap;
 
-pub fn hash_file(path: &str) -> std::io::Result<()> {
+pub fn hash_file(path: &str) -> std::io::Result<String> {
     // The file
     // let file = Path::new(path);
     let file = File::open(&path)?;
@@ -45,14 +45,13 @@ pub fn hash_file(path: &str) -> std::io::Result<()> {
         }
 
         let hash = hasher.finalize();
-        println!("Hash: {}", hash.to_hex());
-
         done.store(true, Ordering::Relaxed);
+        hash.to_hex().to_string()
     });
 
-    hash_thread.join().unwrap();
+    let hash_hex = hash_thread.join().unwrap();
     pb_thread.join().unwrap();
 
-    Ok(())
+    Ok(hash_hex)
 }
 }

--- a/metadata-generator/src/main.rs
+++ b/metadata-generator/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
 
                 let hash = match hash_result {
                     Ok(hash) => {
-                        println!("File hash for {}: {:?}", file_path_str, hash);
+                        println!("File hash for {}: {}", file_path_str, hash);
                         hash
                     }
                     Err(e) => {
@@ -85,7 +85,7 @@ fn main() -> Result<()> {
                 };
                 let file_metadata = MediaFile {
                     file_name: file_path.file_name().unwrap().to_string_lossy().to_string(),
-                    file_hash: format!("{:?}", hash),
+                    file_hash: hash,
                     file_size: file_path.metadata().unwrap().len(),
                     file_type: file_path.extension().unwrap().to_string_lossy().to_string(),
                     file_path: file_path.to_string_lossy().to_string(),


### PR DESCRIPTION
## Summary
- add Rust native GUI with eframe
- update blake3 hashing helper to return hash string
- use new hash return type in CLI
- document how to run the GUI

## Testing
- `cargo build --bin gui --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6887f6fbb8f4832fbe4823a8d700fc59