### PR TITLE
Add Metal-cpp scaffolding for Apple BLAKE3 GPU example

### DIFF
--- a/mojo-blake3/README.md
+++ b/mojo-blake3/README.md
@@ -1,0 +1,27 @@
+# Mojo BLAKE3 GPU Prototype (Apple Silicon)
+
+This directory sketches how we could prototype a deterministic GPU-accelerated BLAKE3 pipeline on Apple Silicon using [Modular Mojo](https://www.modular.com/mojo). The goal is to keep the BLAKE3 output identical to the CPU reference while offloading chunk compression and the Merkle-tree reduction to the GPU cores.
+
+## Proposed layout
+- `src/`
+  - `blake3_gpu.moj`: GPU-first implementation sketch with clearly separated phases (chunk hashing, tree reduction, CPU fallbacks).
+  - `host_pipeline.moj`: Host-side orchestration for streaming large files and handling deterministic batching.
+  - `metal_cpp/`: Metal-cpp scaffolding that mirrors the Mojo layout and demonstrates a fully wired C++ pipeline against Apple GPUs.
+- `tests/`
+  - Placeholder for CPU vs GPU equivalence and performance sanity checks once Mojo has stable GPU runners on macOS.
+
+## Determinism strategy
+- **Fixed chunking**: Keep the canonical 1 KiB BLAKE3 chunks; do not alter the tree topology when scheduling GPU work.
+- **Stable work distribution**: Use deterministic grid/block sizing derived only from input length (e.g., one thread per chunk, fixed workgroup size). Avoid dynamic scheduling or atomics that introduce non-deterministic ordering.
+- **Ordered reductions**: Perform pairwise reductions in a fixed left-to-right order; when the level is odd, carry the last hash forward unchanged to mirror the reference algorithm.
+- **CPU truth source**: Retain a CPU reference implementation and compare every GPU-produced chunk hash during development to guarantee correctness.
+
+## Build & run expectations
+- Requires a Mojo toolchain with Metal backend enabled. On Apple Silicon, GPU dispatch currently needs the nightly toolchains from Modular.
+- A simple driver (see `host_pipeline.moj`) would stream file chunks, copy them to GPU buffers, and read back the final root hash. Until Mojo supports async file I/O on macOS, keep the host loop single-threaded to avoid I/O jitter in benchmarks.
+- For a C++-only reference of the same launch shape, see `src/metal_cpp/metal_blake3_example.cpp`. It uses Metal-cpp to build a minimal compute library in memory, dispatch chunk hashing, and fold hashes deterministically, so Mojo FFI can mirror the same contract.
+
+## Next steps
+1. Flesh out `blake3_gpu.moj` with real kernels once the Metal backend is available in the target environment.
+2. Add tests comparing CPU vs GPU digests for varied file sizes and unaligned endings.
+3. Integrate with the existing BLAKE3 code path by feature flag, falling back to CPU when GPU is unavailable.

--- a/mojo-blake3/src/blake3_gpu.moj
+++ b/mojo-blake3/src/blake3_gpu.moj
@@ -1,0 +1,67 @@
+// Sketch of a deterministic GPU-backed BLAKE3 implementation in Mojo.
+// This file is intentionally non-executable until Mojo exposes stable Metal kernels on macOS.
+// The focus is on code structure and points where determinism matters.
+
+// Constants mirror the official BLAKE3 spec.
+let CHUNK_SIZE: Int = 1024
+let OUT_LEN: Int = 32
+let IV: StaticVector[UInt32, 8] = StaticVector[UInt32, 8](
+    0x6A09E667, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A,
+    0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19
+)
+
+struct ChunkInput:
+    var data: Vector[UInt8]
+    var counter: UInt64
+
+// A device-friendly view of the BLAKE3 block compression step.
+@inline
+fn compress_block(msg: inout StaticVector[UInt32, 16],
+                 chaining_value: StaticVector[UInt32, 8],
+                 counter: UInt64,
+                 block_len: UInt32,
+                 flags: UInt32) -> StaticVector[UInt32, 16]:
+    // TODO: fill with real BLAKE3 round function once GPU intrinsics are ready.
+    // Keep the signature stable to swap in GPU/CPU paths.
+    return StaticVector[UInt32, 16]()
+
+// GPU kernel for hashing one chunk per thread.
+@kernel
+fn hash_chunks(chunks: Pointer[ChunkInput],
+               chunk_count: Int,
+               out_hashes: Pointer[StaticVector[UInt8, OUT_LEN]]):
+    let idx = grid_index_1d()
+    if idx >= chunk_count:
+        return
+
+    // Deterministic: each thread handles exactly one chunk, so ordering is fixed.
+    var input = chunks[idx]
+    var block = StaticVector[UInt32, 16]()
+    // TODO: load message words and call compress_block.
+
+    // Stub: write zeroed hash to make the kernel shape explicit.
+    out_hashes[idx] = StaticVector[UInt8, OUT_LEN]()
+
+// GPU kernel for pairwise reduction of child hashes into parent hashes.
+@kernel
+fn reduce_level(children: Pointer[StaticVector[UInt8, OUT_LEN]],
+                child_count: Int,
+                parents: Pointer[StaticVector[UInt8, OUT_LEN]]):
+    let idx = grid_index_1d()
+    let parent_idx = idx * 2
+    if parent_idx + 1 >= child_count:
+        return  // odd hash count: caller carries the last child forward.
+
+    var left = children[parent_idx]
+    var right = children[parent_idx + 1]
+
+    // TODO: invoke compress_block on concatenated child hashes to produce parent.
+    parents[idx] = left  // placeholder until full compression is wired.
+
+// CPU-visible entry point to keep orchestration separate from kernels.
+fn hash_file_on_gpu(chunks: List[ChunkInput]) -> List[StaticVector[UInt8, OUT_LEN]]:
+    // TODO: upload `chunks` to device buffers and launch `hash_chunks` followed by `reduce_level` until one hash remains.
+    // Determinism notes:
+    //  - grid sizing is derived from chunk count, so launch parameters are repeatable.
+    //  - reductions process pairs in lexical order; odd leaves are carried untouched.
+    return []

--- a/mojo-blake3/src/host_pipeline.moj
+++ b/mojo-blake3/src/host_pipeline.moj
@@ -1,0 +1,22 @@
+// Host-side scaffolding for streaming a large file through the GPU BLAKE3 kernels.
+// Intended for Apple Silicon where Mojo can target Metal.
+// See `src/metal_cpp/metal_blake3_example.cpp` for a C++ reference pipeline using Metal-cpp.
+
+fn read_file_in_chunks(path: String) -> List[ChunkInput]:
+    // TODO: replace with real buffered I/O once available in Mojo.
+    // The function signature encodes deterministic chunk counters for Merkle tree ordering.
+    return []
+
+fn hash_path(path: String) -> StaticVector[UInt8, OUT_LEN]:
+    let chunks = read_file_in_chunks(path)
+    let level_hashes = hash_file_on_gpu(chunks)
+
+    // When hash_file_on_gpu returns multiple hashes (e.g., due to odd chunk counts), fold on CPU
+    // to preserve deterministic ordering until GPU reductions are fully implemented.
+    if level_hashes.size == 0:
+        return StaticVector[UInt8, OUT_LEN]()
+    if level_hashes.size == 1:
+        return level_hashes[0]
+
+    // TODO: call a CPU-side BLAKE3 Merkle reduction for the last few levels as a stopgap.
+    return level_hashes[0]

--- a/mojo-blake3/src/metal_cpp/README.md
+++ b/mojo-blake3/src/metal_cpp/README.md
@@ -1,0 +1,34 @@
+# Metal C++ scaffolding for BLAKE3
+
+This folder holds a minimal, deterministic Metal C++ pipeline that mirrors the Mojo BLAKE3 GPU sketch. It uses the official [Metal-cpp](https://developer.apple.com/metal/cpp/) bindings and keeps the data layout and launch shape explicit for Apple GPUs.
+
+## Contents
+- `metal_blake3_example.cpp`: End-to-end C++ example that sets up the device, builds a tiny Metal compute library from source, encodes chunk hashing and reduction passes, and demonstrates unified-memory reads on Apple Silicon.
+
+## Apple GPU data layout
+Metal GPUs on Apple Silicon use the following layout:
+
+```
+e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024-n8:16:32
+```
+
+We surface this as a compile-time constant in the C++ scaffolding so it can be reused by future Mojo FFI shims when building MLIR targets for Metal.
+
+## Building the example
+The example expects macOS with Xcode toolchains and Metal-cpp headers available (see [Metal-cpp download](https://developer.apple.com/metal/cpp/)).
+
+```bash
+clang++ -std=c++20 -fobjc-arc \
+  -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Metal.framework/Headers \
+  -I/path/to/metal-cpp \
+  mojo-blake3/src/metal_cpp/metal_blake3_example.cpp \
+  -framework Metal -framework Foundation -o metal_blake3_example
+```
+
+Run the binary on Apple Silicon to see the stub hashes returned from the GPU pass:
+
+```bash
+./metal_blake3_example
+```
+
+Once the Mojo GPU kernels are ready, replace the placeholder compute functions in the embedded Metal source string with the real BLAKE3 compression logic and wire Mojo FFI to feed buffers into this pipeline.

--- a/mojo-blake3/src/metal_cpp/metal_blake3_example.cpp
+++ b/mojo-blake3/src/metal_cpp/metal_blake3_example.cpp
@@ -1,0 +1,213 @@
+// Metal-cpp scaffolding for deterministic BLAKE3 hashing on Apple Silicon GPUs.
+// This example builds a tiny compute pipeline entirely in C++ to mirror the Mojo GPU sketch.
+// Replace the placeholder kernels with the real BLAKE3 compression once available.
+
+#include <Metal/Metal.hpp>
+#include <Foundation/Foundation.hpp>
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace blake3_metal {
+
+constexpr const char *kAppleMetalDataLayout =
+    "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-"
+    "f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-"
+    "v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-"
+    "v512:512:512-v1024:1024:1024-n8:16:32";
+
+// Template stub that mirrors the provided signature so it can be wired to Mojo FFI later.
+template <typename C, typename A, typename B>
+bool use_apple_accelerate_lib() {
+    // For now always prefer Apple GPU/Accelerate path when available.
+    return true;
+}
+
+struct ChunkInput {
+    std::array<uint8_t, 1024> data{};
+    uint64_t counter{0};
+};
+
+struct MetalContext {
+    NS::SharedPtr<MTL::Device> device;
+    NS::SharedPtr<MTL::CommandQueue> queue;
+    NS::SharedPtr<MTL::ComputePipelineState> chunk_pipeline;
+    NS::SharedPtr<MTL::ComputePipelineState> reduce_pipeline;
+};
+
+static NS::SharedPtr<MTL::Library> buildLibrary(const NS::SharedPtr<MTL::Device> &device,
+                                               const std::string &source) {
+    NS::Error *error = nullptr;
+    auto ns_source = NS::String::string(source.c_str(), NS::UTF8StringEncoding);
+    auto options = NS::TransferPtr(MTL::CompileOptions::alloc()->init());
+    auto library = NS::TransferPtr(device->newLibrary(ns_source, options.get(), &error));
+    if (error) {
+        std::cerr << "Metal library build failed: "
+                  << NS::String(error->localizedDescription())->utf8String() << std::endl;
+        return nullptr;
+    }
+    return library;
+}
+
+static MetalContext createContext() {
+    MetalContext ctx{};
+    ctx.device = NS::TransferPtr(MTL::CreateSystemDefaultDevice());
+    ctx.queue = NS::TransferPtr(ctx.device->newCommandQueue());
+
+    const std::string metal_source = R"METAL(
+    #include <metal_stdlib>
+    using namespace metal;
+
+    struct ChunkInput { device uchar data[1024]; ulong counter; };
+
+    kernel void blake3_hash_chunks(const device ChunkInput *chunks,
+                                   constant uint &chunk_count,
+                                   device uchar *out_hashes,
+                                   uint gid [[thread_position_in_grid]]) {
+        if (gid >= chunk_count) return;
+        // TODO: load 1024-byte chunk and run real BLAKE3 compression.
+        // Stub writes zero hash (32 bytes) for determinism.
+        const uint base = gid * 32;
+        for (uint i = 0; i < 32; ++i) {
+            out_hashes[base + i] = 0;
+        }
+    }
+
+    kernel void blake3_reduce_level(const device uchar *child_hashes,
+                                    constant uint &child_count,
+                                    device uchar *parent_hashes,
+                                    uint gid [[thread_position_in_grid]]) {
+        uint parent_idx = gid * 2;
+        if (parent_idx + 1 >= child_count) return; // odd child carried by host
+        uint in_base = parent_idx * 32;
+        uint out_base = gid * 32;
+        // TODO: run compress(left||right). For now copy left deterministically.
+        for (uint i = 0; i < 32; ++i) {
+            parent_hashes[out_base + i] = child_hashes[in_base + i];
+        }
+    }
+    )METAL";
+
+    auto library = buildLibrary(ctx.device, metal_source);
+    auto chunk_fn = NS::String::string("blake3_hash_chunks", NS::UTF8StringEncoding);
+    auto reduce_fn = NS::String::string("blake3_reduce_level", NS::UTF8StringEncoding);
+
+    NS::Error *error = nullptr;
+    auto chunk_function = NS::TransferPtr(library->newFunction(chunk_fn));
+    ctx.chunk_pipeline = NS::TransferPtr(ctx.device->newComputePipelineState(chunk_function.get(), &error));
+    if (error) {
+        std::cerr << "Chunk pipeline build failed: "
+                  << NS::String(error->localizedDescription())->utf8String() << std::endl;
+    }
+
+    auto reduce_function = NS::TransferPtr(library->newFunction(reduce_fn));
+    ctx.reduce_pipeline = NS::TransferPtr(ctx.device->newComputePipelineState(reduce_function.get(), &error));
+    if (error) {
+        std::cerr << "Reduce pipeline build failed: "
+                  << NS::String(error->localizedDescription())->utf8String() << std::endl;
+    }
+    return ctx;
+}
+
+static std::vector<std::array<uint8_t, 32>> hashChunks(MetalContext &ctx,
+                                                      const std::vector<ChunkInput> &chunks) {
+    if (!ctx.chunk_pipeline) return {};
+    const uint32_t chunk_count = static_cast<uint32_t>(chunks.size());
+    auto command_buffer = NS::TransferPtr(ctx.queue->commandBuffer());
+    auto encoder = NS::TransferPtr(command_buffer->computeCommandEncoder());
+    encoder->setComputePipelineState(ctx.chunk_pipeline.get());
+
+    auto chunk_buffer = NS::TransferPtr(ctx.device->newBuffer(chunks.data(),
+                                                              sizeof(ChunkInput) * chunks.size(),
+                                                              MTL::ResourceStorageModeShared));
+    auto out_buffer = NS::TransferPtr(ctx.device->newBuffer(32 * chunks.size(),
+                                                            MTL::ResourceStorageModeShared));
+
+    encoder->setBuffer(chunk_buffer.get(), 0, 0);
+    encoder->setBytes(&chunk_count, sizeof(chunk_count), 1);
+    encoder->setBuffer(out_buffer.get(), 0, 2);
+
+    MTL::Size grid(chunk_count, 1, 1);
+    auto max_threads = ctx.chunk_pipeline->maxTotalThreadsPerThreadgroup();
+    MTL::Size tg(std::min<uint32_t>(max_threads, 64), 1, 1);
+    encoder->dispatchThreads(grid, tg);
+    encoder->endEncoding();
+    command_buffer->commit();
+    command_buffer->waitUntilCompleted();
+
+    std::vector<std::array<uint8_t, 32>> hashes(chunks.size());
+    std::memcpy(hashes.data(), out_buffer->contents(), 32 * chunks.size());
+    return hashes;
+}
+
+static std::vector<std::array<uint8_t, 32>> reduceLevel(MetalContext &ctx,
+                                                       const std::vector<std::array<uint8_t, 32>> &children) {
+    if (!ctx.reduce_pipeline) return {};
+    if (children.size() < 2) return children;
+
+    const uint32_t child_count = static_cast<uint32_t>(children.size());
+    const uint32_t parent_count = child_count / 2;
+
+    auto command_buffer = NS::TransferPtr(ctx.queue->commandBuffer());
+    auto encoder = NS::TransferPtr(command_buffer->computeCommandEncoder());
+    encoder->setComputePipelineState(ctx.reduce_pipeline.get());
+
+    auto child_buffer = NS::TransferPtr(ctx.device->newBuffer(children.data(),
+                                                              32 * children.size(),
+                                                              MTL::ResourceStorageModeShared));
+    auto parent_buffer = NS::TransferPtr(ctx.device->newBuffer(32 * parent_count,
+                                                               MTL::ResourceStorageModeShared));
+
+    encoder->setBuffer(child_buffer.get(), 0, 0);
+    encoder->setBytes(&child_count, sizeof(child_count), 1);
+    encoder->setBuffer(parent_buffer.get(), 0, 2);
+
+    MTL::Size grid(parent_count, 1, 1);
+    auto max_threads = ctx.reduce_pipeline->maxTotalThreadsPerThreadgroup();
+    MTL::Size tg(std::min<uint32_t>(max_threads, 64), 1, 1);
+    encoder->dispatchThreads(grid, tg);
+    encoder->endEncoding();
+    command_buffer->commit();
+    command_buffer->waitUntilCompleted();
+
+    std::vector<std::array<uint8_t, 32>> parents(parent_count);
+    std::memcpy(parents.data(), parent_buffer->contents(), 32 * parent_count);
+
+    // Deterministic carry of odd child to preserve Merkle ordering.
+    if (child_count % 2 == 1) {
+        parents.push_back(children.back());
+    }
+    return parents;
+}
+
+static std::array<uint8_t, 32> hashFile(const std::vector<ChunkInput> &chunks) {
+    MetalContext ctx = createContext();
+    auto level = hashChunks(ctx, chunks);
+    while (level.size() > 1) {
+        level = reduceLevel(ctx, level);
+    }
+    if (level.empty()) return {};
+    return level.front();
+}
+
+}  // namespace blake3_metal
+
+int main() {
+    using namespace blake3_metal;
+    std::vector<ChunkInput> inputs(2);
+    inputs[0].counter = 0;
+    inputs[1].counter = 1;
+
+    auto root_hash = hashFile(inputs);
+    std::cout << "Got stub hash bytes: ";
+    for (auto b : root_hash) {
+        std::cout << std::hex << static_cast<int>(b) << " ";
+    }
+    std::cout << std::dec << "\n";
+    std::cout << "Apple Metal data layout: " << kAppleMetalDataLayout << "\n";
+    return 0;
+}

--- a/mojo-blake3/tests/README.md
+++ b/mojo-blake3/tests/README.md
@@ -1,0 +1,6 @@
+# Test plan (future)
+
+This folder will house CPU vs GPU equivalence tests once the Mojo Metal backend is available in CI. Suggested cases:
+- Empty file, single-chunk file, and multi-chunk file with uneven tail.
+- Cross-check GPU hashes against the official BLAKE3 test vectors.
+- Performance smoke tests that ensure deterministic timing by pinning grid/block sizes and running multiple iterations.


### PR DESCRIPTION
## Summary
- add Metal-cpp folder with example pipeline showing deterministic chunk hashing and reductions on Apple GPUs
- surface Apple Metal data layout constant and stub `use_apple_accelerate_lib` for future Mojo FFI
- document how to build and run the C++ example and link it from the Mojo BLAKE3 prototype docs

## Testing
- not run (scaffolding and documentation only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926fd8368f8832f8b3da051ebc3e53a)